### PR TITLE
Create .pfizer.yml file per Repository Identification policy

### DIFF
--- a/.pfizer.yml
+++ b/.pfizer.yml
@@ -1,0 +1,12 @@
+---
+####
+# All Pfizer repos are required to identify themselves with a .pfizer.yml file.
+# https://confluence.pfizer.com/display/DSOEPipeline/Repository+Identification
+####
+
+####
+## You can lookup cmdb_id from https://acie.pfizer.com/App
+## If an application is not listed in ACIE `~` is an acceptable value.
+###
+cmdb_id: SC2968028
+primary_contact: ARVANK01


### PR DESCRIPTION

This pull request contains a `.pfizer.yml` file indicating the reposotory owner `NTID`, an optional `cmdb_id`, and GitHub migration source metadata.

Please review and merge this _as soon as possible_.

**Note that Pfizer _may_ archive repositories lacking a valid `.pfizer.yml` file in the default branch.**

See the [Github Policies: Repository Identification](https://confluence.pfizer.com/display/DSOEPipeline/Repository+Identification) documentation for instructions on constructing and maintaining the`.pfizer.yml` file.
